### PR TITLE
Allow people to enter themselves into the queue multiple times

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -106,7 +106,10 @@ module.exports.advance = function() {
  */
 module.exports.remove = function(item) {
   var start = db.queue.length;
-  _.pullAt(db.queue, _.findIndex(db.queue, item));
+  _.remove(db.queue, function(entry) {
+    return _.isEqual(entry, item);
+  });
+
   brain.set('db', db);
   return start - db.queue.length;
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -102,12 +102,13 @@ module.exports.advance = function() {
 /**
  * Removes all instances of the item from the queue.
  * @param item
+ * @param isEqual Equality checker
  * @returns {number} Returns the number or items removed
  */
-module.exports.remove = function(item) {
+module.exports.remove = function(item, isEqual) {
   var start = db.queue.length;
   _.remove(db.queue, function(entry) {
-    return _.isEqual(entry, item);
+    return isEqual(entry, item);
   });
 
   brain.set('db', db);

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -101,14 +101,18 @@ describe('Queue', function() {
     queue.push(walter);
 
     expect(queue.length()).to.equal(2);
-    queue.remove({name: 'jesse'});
+    queue.remove({name: 'jesse'}, function(a, b) {
+      return a.name === b.name;
+    });
     expect(queue.length()).to.equal(1);
     expect(queue.contains({name: 'jesse'})).to.be.false;
 
     queue.push(jesse);
 
     expect(queue.length()).to.equal(2);
-    queue.remove({name: 'jesse'});
+    queue.remove({name: 'jesse'}, funciton(a, b) {
+      return a.name === b.name;
+    });
     expect(queue.length()).to.equal(1);
     expect(queue.contains({name: 'jesse'})).to.be.false;
   });


### PR DESCRIPTION
This in theory allows you to add yourself multiple times to the deploy queue.

## Behavior
- `remove|kick` now drop _all_ instances of you in the queue.
- Some new messages for situations that didn't previously exist (deploy done but you're up next, added to the deploy queue but you're already deploying, etc)
- Who's deploying might return the same name several times

I am not certain that all or some of this isn't broken