### PR TITLE
Message in channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ module.exports = function(robot) {
     } else if (isCurrent && length == grouped.length) {
       res.reply('Ok! You are now deploying ' + grouped.length + ' things in a row.');
     } else {
-      res.reply('There\'s ' + (length - 1) + ' things to deploy in the queue ahead of you. I\'ll let you know when you\'re up.');
+      var preamble = length === 2 ? 'There\'s ' : 'There\'re ';
+      res.reply(preamble + (length - 1) + ' things to deploy in the queue ahead of you. I\'ll let you know when you\'re up.');
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ module.exports = function(robot) {
     }
 
     if (!queue.isEmpty() && !queue.isCurrent(user)) {
-      // Send DM to next in line if the queue isn't empty and it's not the person who just finished deploying.
+      // Message about the next user to make the queue more obvious
+      res.reply(queue.current().name + ' is up next');
+      // Send message to next in line if the queue isn't empty and it's not the person who just finished deploying.
       notifyUser(queue.current());
     }
   }


### PR DESCRIPTION
Send a message to the channel where someone `deploy done`-d. 

Originally I wanted to get rid of the DM, but I think we need both since if someone decided to `deploy done` in a DM with `davidbot` then the next up person would not get any message.

If there's a way to specify the exact Slack channel, I'm open to that idea, but I think I like the idea of getting a DM. It might be a little irritating if you up next to get two messages though. Thoughts?