### PR TITLE
Use user ID

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -105,11 +105,9 @@ module.exports.advance = function() {
  * @param isEqual Equality checker
  * @returns {number} Returns the number or items removed
  */
-module.exports.remove = function(item, isEqual) {
+module.exports.remove = function(predicate) {
   var start = db.queue.length;
-  _.remove(db.queue, function(entry) {
-    return isEqual(entry, item);
-  });
+  _.remove(db.queue, predicate);
 
   brain.set('db', db);
   return start - db.queue.length;


### PR DESCRIPTION
Use user ID as identifier instead of name. This fixes messaging a user directly. In the latest slack hubot adapter, sending to a user must be done via their user ids instead. We now also use slack display names instead if available.